### PR TITLE
Possibility to use StrongMigrations instead of importing

### DIFF
--- a/lib/strong_migrations.ex
+++ b/lib/strong_migrations.ex
@@ -31,6 +31,13 @@ defmodule StrongMigrations do
     |> ReasonsTranslator.translate()
   end
 
+  defmacro __using__(_opts) do
+    quote do
+      use Ecto.Migration
+      import StrongMigrations
+    end
+  end
+
   defmacro safety_assured(do: expression) do
     quote do
       unquote(expression)


### PR DESCRIPTION
Thanks to that we could avoid in migrations doing things like:
```ex
use Ecto.Migration
import StrongMigrations
```

Right now it's fine to do that like:
```ex
use StrongMigrations
```