### PR TITLE
Return error code if unsafe migration

### DIFF
--- a/lib/task/strong_migrations/migrate.ex
+++ b/lib/task/strong_migrations/migrate.ex
@@ -20,5 +20,6 @@ defmodule Mix.Tasks.StrongMigrations.Migrate do
     Enum.each(reasons, fn reason -> Logger.warn(reason) end)
 
     Logger.error("Found #{length(reasons)} unsafe migrations!")
+    System.stop(1)
   end
 end


### PR DESCRIPTION
It's to fail CI
Exemple in Elixir `--warnings-as-errors`: https://github.com/elixir-lang/elixir/blob/e6118608d668d307ccff2d6c1d90953c225d180d/lib/mix/lib/mix/compilers/test.ex#L58

Explanation of each exit code https://www.geeksforgeeks.org/exit-codes-in-c-c-with-examples/

To verify exit code returned, run it after run the task:
```bash
echo $?
```